### PR TITLE
Add watchdog restart flow for accessibility service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,6 +105,10 @@
                 android:resource="@xml/accessibility_service_config" />
         </service>
 
+        <receiver
+            android:name=".accessibility.AccessibilityServiceRestartReceiver"
+            android:exported="false" />
+
         <!-- HaramBlur Device Admin Receiver for enhanced app blocking -->
         <!-- This enables force-closing of blocked apps for stronger enforcement -->
         <!-- Device Admin access is optional and enhances blocking capabilities -->

--- a/app/src/main/java/com/hieltech/haramblur/accessibility/AccessibilityServiceRestartReceiver.kt
+++ b/app/src/main/java/com/hieltech/haramblur/accessibility/AccessibilityServiceRestartReceiver.kt
@@ -1,0 +1,82 @@
+package com.hieltech.haramblur.accessibility
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.util.Log
+
+/**
+ * Broadcast receiver triggered by the watchdog alarm. It ensures the accessibility service
+ * is running and attempts to restart it if necessary.
+ */
+class AccessibilityServiceRestartReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != AccessibilityServiceWatchdog.ACTION_CHECK_SERVICE) {
+            Log.d(TAG, "Ignoring unrelated action: ${intent?.action}")
+            return
+        }
+
+        val serviceRunning = HaramBlurAccessibilityService.isServiceRunning()
+        Log.d(TAG, "Watchdog triggered. Service running: $serviceRunning")
+        if (serviceRunning) {
+            AccessibilityServiceWatchdog.cancel(context, "service_already_running")
+            return
+        }
+
+        if (!isAccessibilityServiceEnabled(context)) {
+            Log.w(TAG, "Accessibility service disabled by user; watchdog will not restart")
+            AccessibilityServiceWatchdog.cancel(context, "service_disabled")
+            return
+        }
+
+        runCatching {
+            val serviceIntent = Intent(context, HaramBlurAccessibilityService::class.java).apply {
+                putExtra(EXTRA_WATCHDOG_RESTART, true)
+            }
+            context.startService(serviceIntent)
+            Log.w(TAG, "Restart intent dispatched to HaramBlurAccessibilityService")
+        }.onFailure { error ->
+            Log.e(TAG, "Failed to dispatch restart intent", error)
+            AccessibilityServiceWatchdog.scheduleRetry(context, "restart_failure")
+            return
+        }
+
+        AccessibilityServiceWatchdog.schedule(context, "verify_restart", delayMs = VERIFY_DELAY_MS)
+    }
+
+    private fun isAccessibilityServiceEnabled(context: Context): Boolean {
+        return try {
+            val accessibilityEnabled = Settings.Secure.getInt(
+                context.contentResolver,
+                Settings.Secure.ACCESSIBILITY_ENABLED, 0
+            ) == 1
+
+            if (!accessibilityEnabled) {
+                Log.w(TAG, "System accessibility disabled")
+                return false
+            }
+
+            val enabledServices = Settings.Secure.getString(
+                context.contentResolver,
+                Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+            ) ?: return false
+
+            val expectedComponent = ComponentName(context, HaramBlurAccessibilityService::class.java)
+            val flattenedComponent = expectedComponent.flattenToString()
+
+            enabledServices.split(':').any { it.equals(flattenedComponent, ignoreCase = true) }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking accessibility service status", e)
+            false
+        }
+    }
+
+    companion object {
+        private const val TAG = "AccessibilityRestartRcvr"
+        private const val VERIFY_DELAY_MS = 10_000L
+        const val EXTRA_WATCHDOG_RESTART = "extra_watchdog_restart"
+    }
+}

--- a/app/src/main/java/com/hieltech/haramblur/accessibility/AccessibilityServiceWatchdog.kt
+++ b/app/src/main/java/com/hieltech/haramblur/accessibility/AccessibilityServiceWatchdog.kt
@@ -1,0 +1,97 @@
+package com.hieltech.haramblur.accessibility
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+/**
+ * Utility object that manages watchdog alarms for the accessibility service.
+ * It ensures the service is restarted if the system terminates it unexpectedly.
+ */
+object AccessibilityServiceWatchdog {
+
+    private const val TAG = "AccessibilityWatchdog"
+    private const val WATCHDOG_REQUEST_CODE = 1001
+    private const val DEFAULT_DELAY_MS = 5_000L
+    private const val RETRY_DELAY_MS = 15_000L
+
+    const val ACTION_CHECK_SERVICE = "com.hieltech.haramblur.action.CHECK_ACCESSIBILITY_SERVICE"
+
+    /**
+     * Schedule a watchdog alarm that will trigger a restart check for the accessibility service.
+     *
+     * @param context Context used to obtain [AlarmManager]
+     * @param reason Descriptive reason used for logging
+     * @param delayMs Delay in milliseconds before the watchdog fires
+     */
+    fun schedule(context: Context, reason: String, delayMs: Long = DEFAULT_DELAY_MS) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        if (alarmManager == null) {
+            Log.w(TAG, "AlarmManager not available; cannot schedule watchdog ($reason)")
+            return
+        }
+
+        val pendingIntent = getPendingIntent(context, createIfMissing = true) ?: return
+        val triggerAtMillis = System.currentTimeMillis() + delayMs
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            } else {
+                alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+            }
+            Log.w(TAG, "Watchdog scheduled in ${delayMs}ms (reason: $reason)")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to schedule watchdog alarm", e)
+        }
+    }
+
+    /**
+     * Cancel any pending watchdog alarms.
+     */
+    fun cancel(context: Context, reason: String? = null) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        if (alarmManager == null) {
+            Log.w(TAG, "AlarmManager not available; cannot cancel watchdog${reason?.let { " ($it)" } ?: ""}")
+            return
+        }
+
+        val pendingIntent = getPendingIntent(context, createIfMissing = false)
+        if (pendingIntent == null) {
+            Log.d(TAG, "No watchdog alarm to cancel${reason?.let { " ($it)" } ?: ""}")
+            return
+        }
+
+        try {
+            alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
+            Log.d(TAG, "Watchdog alarm canceled${reason?.let { " ($it)" } ?: ""}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to cancel watchdog alarm", e)
+        }
+    }
+
+    /**
+     * Schedule a retry after a failed restart attempt.
+     */
+    fun scheduleRetry(context: Context, reason: String = "retry") {
+        schedule(context, reason, RETRY_DELAY_MS)
+    }
+
+    private fun getPendingIntent(context: Context, createIfMissing: Boolean): PendingIntent? {
+        val intent = Intent(context, AccessibilityServiceRestartReceiver::class.java).apply {
+            action = ACTION_CHECK_SERVICE
+        }
+
+        val flags = if (createIfMissing) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE
+        }
+
+        return PendingIntent.getBroadcast(context, WATCHDOG_REQUEST_CODE, intent, flags)
+    }
+}

--- a/app/src/main/java/com/hieltech/haramblur/accessibility/HaramBlurAccessibilityService.kt
+++ b/app/src/main/java/com/hieltech/haramblur/accessibility/HaramBlurAccessibilityService.kt
@@ -36,6 +36,9 @@ class HaramBlurAccessibilityService : AccessibilityService() {
         private const val TAG = "HaramBlurAccessibilityService"
         private var instance: HaramBlurAccessibilityService? = null
         private const val EMERGENCY_RESET_ACTION = "com.hieltech.haramblur.EMERGENCY_RESET"
+        private const val WATCHDOG_REASON_DESTROY = "service_destroyed"
+        private const val WATCHDOG_REASON_TASK_REMOVED = "task_removed"
+        private const val WATCHDOG_REASON_ACTIVE = "service_active"
 
         fun getInstance(): HaramBlurAccessibilityService? = instance
 
@@ -160,6 +163,8 @@ class HaramBlurAccessibilityService : AccessibilityService() {
         instance = this
         Log.d(TAG, "HaramBlur Accessibility Service Created")
 
+        AccessibilityServiceWatchdog.cancel(this, WATCHDOG_REASON_ACTIVE)
+
         // Register emergency reset broadcast receiver
         val filter = IntentFilter(EMERGENCY_RESET_ACTION)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
@@ -180,6 +185,8 @@ class HaramBlurAccessibilityService : AccessibilityService() {
     
     override fun onDestroy() {
         super.onDestroy()
+
+        performTerminationCleanup("onDestroy")
 
         // Unregister emergency reset broadcast receiver
         try {
@@ -202,7 +209,7 @@ class HaramBlurAccessibilityService : AccessibilityService() {
 
         // Clean up all components
         cleanupComponents()
-        
+
         // Clean up dhikr manager
         try {
             dhikrManager.cleanup()
@@ -214,12 +221,16 @@ class HaramBlurAccessibilityService : AccessibilityService() {
         serviceScope.cancel()
         instance = null
         Log.d(TAG, "HaramBlur Accessibility Service Destroyed")
+
+        AccessibilityServiceWatchdog.schedule(this, WATCHDOG_REASON_DESTROY)
     }
-    
+
     override fun onServiceConnected() {
         super.onServiceConnected()
         Log.d(TAG, "HaramBlur Accessibility Service Connected")
-        
+
+        AccessibilityServiceWatchdog.cancel(this, WATCHDOG_REASON_ACTIVE)
+
         serviceScope.launch {
             startContentMonitoring()
 
@@ -250,6 +261,13 @@ class HaramBlurAccessibilityService : AccessibilityService() {
                 }
             }
         }
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        Log.w(TAG, "HaramBlur Accessibility Service task removed")
+        performTerminationCleanup("onTaskRemoved")
+        AccessibilityServiceWatchdog.schedule(this, WATCHDOG_REASON_TASK_REMOVED)
+        super.onTaskRemoved(rootIntent)
     }
     
     private suspend fun initializeComponents() {
@@ -866,12 +884,40 @@ class HaramBlurAccessibilityService : AccessibilityService() {
             stopContentMonitoring()
             contentDetectionEngine.cleanup()
             // blurOverlayManager cleanup is handled in stopContentMonitoring
-            
+
             // Cleanup all enhanced detection services
             serviceLifecycleManager.cleanupServices()
         } catch (e: Exception) {
             Log.e(TAG, "Error during cleanup", e)
         }
+    }
+
+    private fun performTerminationCleanup(reason: String) {
+        Log.w(TAG, "Ensuring overlays and screen capture are stopped ($reason)")
+
+        if (this::blurOverlayManager.isInitialized) {
+            runCatching { hideBlockedSiteOverlay() }.onFailure {
+                Log.e(TAG, "Failed to hide blocked site overlay during $reason", it)
+            }
+
+            runCatching { blurOverlayManager.hideBlurOverlay() }.onFailure {
+                Log.e(TAG, "Failed to hide blur overlay during $reason", it)
+            }
+        } else {
+            Log.w(TAG, "BlurOverlayManager not initialized; skipping overlay cleanup")
+        }
+
+        if (this::screenCaptureManager.isInitialized) {
+            runCatching { screenCaptureManager.stopCapturing() }.onFailure {
+                Log.e(TAG, "Failed to stop screen capture during $reason", it)
+            }
+        } else {
+            Log.w(TAG, "ScreenCaptureManager not initialized; skipping capture stop")
+        }
+
+        isProcessingActive = false
+        isCurrentlyBlurred = false
+        isShowingBlockedSiteOverlay = false
     }
     
     // Public methods for external control


### PR DESCRIPTION
## Summary
- ensure the accessibility service always clears overlays and stops screen capture when destroyed or removed
- add a watchdog utility plus restart receiver to reschedule the accessibility service when it unexpectedly stops
- register the restart receiver in the manifest so alarms can fire while the app is backgrounded

## Testing
- ./gradlew --console=plain --no-daemon -Dorg.gradle.java.home=$JAVA_HOME compileDebugKotlin *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c89de182ec8325be69688480753437